### PR TITLE
[codex] Add agentic memory core

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # DocThinker
 
-**Self-Evolving Knowledge Graphs · Tiered Memory · Structured Reasoning**
+**Agentic Memory Framework · Self-Evolving Knowledge Graphs · Document Reasoning**
 
 *Language captures the results of cognition, while cognition itself encompasses perception, experience, and reasoning.*
 
@@ -26,12 +26,9 @@
 
 <br>
 
-**DocThinker** is a document-driven RAG system that constructs self-evolving knowledge graphs from uploaded documents. Unlike conventional retrieve-then-respond pipelines, DocThinker treats knowledge as a **dynamic graph**.
+**DocThinker** is an agentic memory framework for document understanding. It turns documents, chat turns, retrieval traces, and graph expansions into a multi-layer memory system that can recall, reason, and consolidate knowledge over time.
 
-### 🎬 Explore our Tutorial!!
-
-<!-- TODO: Replace with demo video -->
-> [▶️ **Watch the YouTube Tutorial**](#) | [🚀 **Use DocThinker in HuggingFace Space**](#) | [📝 **Try Colab Tutorial**](#)
+Unlike a conventional retrieve-then-respond RAG pipeline, DocThinker treats knowledge as an evolving memory substrate: session-scoped knowledge graphs provide semantic memory, Claw provides tiered conversation memory, Neuro Memory provides episodic analogies, and KG expansion tracks hypotheses that can be promoted through use.
 
 ---
 
@@ -41,13 +38,13 @@
 - [🔥 Quick Start](#-quick-start)
   - [1. Web UI & Server](#1-web-ui--server)
   - [2. Python API Usage](#2-python-api-usage)
-- [🧬 Key Contributions (Pipeline)](#-key-contributions)
-  - [1. Test-Time Scaling & Agentic Memory](#1--test-time-scaling--agentic-memory)
-  - [2. Two-Path KG Self-Expansion](#2--two-path-kg-self-expansion)
-  - [3. Self-Evolving Knowledge Graph](#3--self-evolving-knowledge-graph)
-  - [4. Multi-Agent Co-Evolution](#4--multi-agent-co-evolution)
-  - [5. Tiered Conversation Memory (Claw)](#5--tiered-conversation-memory-claw)
-  - [6. SPARQL Chain-of-Thought Reasoning](#6--sparql-chain-of-thought-cot-reasoning)
+- [🧬 Key Contributions](#-key-contributions)
+  - [1. Agentic Memory Core](#1--agentic-memory-core)
+  - [2. Session-Scoped Knowledge Graphs](#2--session-scoped-knowledge-graphs)
+  - [3. Self-Evolving KG Expansion](#3--self-evolving-kg-expansion)
+  - [4. Tiered Conversation Memory (Claw)](#4--tiered-conversation-memory-claw)
+  - [5. Episodic Analogy Memory](#5--episodic-analogy-memory)
+  - [6. Multimodal Retrieval Signals](#6--multimodal-retrieval-signals)
 - [💡 Use Cases](#-use-cases)
 - [⚡ Query Modes & PDF Processing](#-query-modes)
 - [📡 API Reference](#-api-reference)
@@ -111,11 +108,8 @@ async def main():
     # 3. Ingest Document (Parsing & Knowledge Graph Construction)
     await dt.process_document_complete("your_document.pdf")
     
-    # 4. Trigger Test-Time Scaling (Self-Study Loop) to enhance KG density
-    await dt.run_self_study_loop(max_rounds=5)
-    
-    # 5. Query with SPARQL CoT Reasoning
-    response = await dt.aquery("What is the core idea of the document?", mode="deep")
+    # 4. Query the session knowledge graph
+    response = await dt.aquery("What is the core idea of the document?", mode="mix")
     print(response)
 
 asyncio.run(main())
@@ -125,44 +119,49 @@ asyncio.run(main())
 
 ## 🧬 Key Contributions
 
-DocThinker splits the monolithic pipeline into autonomous agents and introduces graph-based cognitive reasoning.
+DocThinker organizes retrieval and memory as an agent-facing framework instead of scattering memory logic across API handlers.
 
 <div align="center">
 <img src="docs/assets/pipeline.png" alt="DocThinker Pipeline" width="820" />
 <p><b>Figure 1.</b> DocThinker end-to-end pipeline — from document input to knowledge graph construction, tiered memory management, hybrid retrieval & reasoning, and output with feedback back to the graph.</p>
 </div>
 
-### 1. 🧠 Test-Time Scaling & Agentic Memory
-Between document ingestion and user querying, DocThinker runs a **background self-study loop** (Test-Time Scaling on KG). The LLM autonomously analyzes existing subgraphs, generates questions, retrieves answers, performs continuous deductive reasoning, and writes back new knowledge and methodological experiences (`entity_type="experience"`). This significantly increases graph density and reasoning capability *without* requiring additional user prompts.
+### 1. 🧠 Agentic Memory Core
+`docthinker.memory_core.AgentMemoryCore` is the stable facade for agent memory work. Before generation, `recall()` merges:
 
-### 2. 🔀 Two-Path KG Self-Expansion
+* Claw working/core/archive conversation memory.
+* Neuro Memory episodic analogy matches.
+* KG expanded-node matches and forced retrieval instructions.
+
+After generation, `after_response()` consolidates the turn back into memory layers, writes chat episodes, optionally feeds the Q&A back into the graph, and promotes useful expanded nodes.
+
+### 2. 🧩 Session-Scoped Knowledge Graphs
+Each session owns its own GraphCore-backed knowledge graph and document state. Uploaded files are parsed, inserted, and queried within that session, which keeps user context isolated while still allowing the graph to grow over time.
+
+### 3. 🔀 Self-Evolving KG Expansion
 Expansion operates in two complementary passes:
 * **Path A (Cluster-based):** HDBSCAN clusters entity embeddings → LLM generates cluster summaries → expands new entities grounded in cluster themes.
 * **Path B (Top-N multi-angle):** Top-50 highest-degree nodes expanded across 6 cognitive dimensions (hierarchy, causation, analogy, contrast, temporal, application).
 
-### 3. 🔄 Self-Evolving Knowledge Graph
-Newly expanded nodes do not immediately become authoritative knowledge — they enter the graph as `candidates`. Only when users repeatedly adopt a node in actual conversations do its usage count and score accumulate; once thresholds are met, the node is promoted to a formal part of the graph.
-
-### 4. 🤖 Multi-Agent Co-Evolution
-DocThinker splits the traditional RAG monolithic pipeline into three specialized Agents:
-* **Retrieval Agent:** Maximizes retrieval hit rate.
-* **Extraction Agent:** Maximizes extraction coverage.
-* **Answering Agent:** Generates final answers and triggers node promotion/decay feedback.
+Newly expanded nodes do not immediately become authoritative knowledge. They enter as candidates, are matched during query time, and only become formal graph nodes after repeated useful adoption in assistant responses.
 
 <div align="center">
-<img src="docs/assets/multi_agent_evolution.png" alt="Multi-Agent Co-Evolution Architecture" width="820" />
-<p><sub><b>Figure 2.</b> DocThinker multi-Agent co-evolution architecture.</sub></p>
+<img src="docs/assets/multi_agent_evolution.png" alt="Memory and graph feedback architecture" width="820" />
+<p><sub><b>Figure 2.</b> Memory and graph feedback loop.</sub></p>
 </div>
 
-### 5. 🗃️ Tiered Conversation Memory (Claw)
-Inspired by the [OpenClaw / Letta](https://github.com/letta-ai/letta) architecture, Claw implements a **three-layer memory hierarchy** (Hot, Warm, Cold) for unbounded conversation length.
+### 4. 🗃️ Tiered Conversation Memory (Claw)
+Claw implements a three-layer memory hierarchy for long-running conversations: hot working memory, warm core summaries, and cold semantic archives.
 
-### 6. 🧠 SPARQL Chain-of-Thought (CoT) Reasoning
-Complex queries are internally decomposed into **SPARQL-style triple-pattern chains** before answer generation. The LLM binds variables against KG context via shared-variable chaining.
+### 5. 🧠 Episodic Analogy Memory
+Neuro Memory stores chat/document experiences as episodes and retrieves similar past situations as analogy context. These matches are surfaced through `episodic_matches` and injected as guidance rather than treated as direct factual sources.
 
 <div align="center">
-<img src="docs/assets/sparql_cot.png" alt="SPARQL CoT Reasoning" width="680" />
+<img src="docs/assets/sparql_cot.png" alt="Structured reasoning" width="680" />
 </div>
+
+### 6. 🖼️ Multimodal Retrieval Signals
+DocThinker tracks image assets extracted from documents and can activate relevant visual evidence during deep UI queries.
 
 ---
 
@@ -179,7 +178,7 @@ Complex queries are internally decomposed into **SPARQL-style triple-pattern cha
 </td>
 <td width="50%" valign="top">
 
-> *"Deep-mode conversation with SPARQL CoT reasoning and tiered memory"*
+> *"Deep-mode conversation with episodic memory, expanded KG matching, and tiered memory"*
 
 <img src="docs/assets/usecase_chat.gif" width="100%"/>
 
@@ -191,11 +190,11 @@ Complex queries are internally decomposed into **SPARQL-style triple-pattern cha
 
 ## ⚡ Query Modes
 
-| Mode | Strategy | Latency | Depth |
-|------|----------|---------|-------|
-| **Fast** | Vector similarity | ~1 s | Shallow |
-| **Standard** | Hybrid KG + vector + reranking | ~3 s | Medium |
-| **Deep** | SPARQL CoT + spreading activation + episodic memory + expansion matching + post-query feedback | ~8 s | Full |
+| Mode | UI mapping | Strategy | Depth |
+|------|------------|----------|-------|
+| **Quick** | `naive` | Lightweight vector-style retrieval, rerank disabled | Shallow |
+| **Standard** | `local` | Session KG retrieval with reranking | Medium |
+| **Deep** | `mix` | KG + vector retrieval, Claw memory, episodic analogies, expanded-node matching, image activation, post-query consolidation | Full |
 
 ---
 
@@ -216,19 +215,20 @@ Complex queries are internally decomposed into **SPARQL-style triple-pattern cha
 
 | Category | Endpoint | Method | Description |
 |----------|----------|--------|-------------|
-| Sessions | `/sessions` | GET / POST | List / create sessions |
-| | `/sessions/{id}/history` | GET | Chat history |
-| | `/sessions/{id}/files` | GET | Ingested files |
-| Ingest | `/ingest` | POST | Upload PDF / TXT |
-| | `/ingest/stream` | POST | Stream raw text |
-| Query | `/query/stream` | POST | SSE streaming query |
-| | `/query` | POST | Non-streaming query |
-| KG | `/knowledge-graph/data` | GET | Nodes + edges for visualization |
-| | `/knowledge-graph/expand` | POST | Trigger 2-path expansion |
-| | `/knowledge-graph/stats` | GET | KG statistics |
-| Memory | `/memory/stats` | GET | Episode + Claw memory stats |
-| | `/memory/consolidate` | POST | Run episodic consolidation |
-| Settings | `/settings` | GET / POST | Runtime config |
+| Sessions | `/api/v1/sessions` | GET / POST | List / create sessions |
+| | `/api/v1/sessions/{id}/history` | GET | Chat history |
+| | `/api/v1/sessions/{id}/files` | GET | Ingested files |
+| Ingest | `/api/v1/ingest` | POST | Upload PDF / TXT |
+| | `/api/v1/ingest/stream` | POST | Stream raw text |
+| Query | `/api/v1/query/stream` | POST | SSE streaming query |
+| | `/api/v1/query` | POST | Non-streaming query |
+| | `/api/v1/query/text` | POST | Alias for non-streaming query |
+| KG | `/api/v1/knowledge-graph/data` | GET | Nodes + edges for visualization |
+| | `/api/v1/knowledge-graph/expand` | POST | Trigger KG expansion |
+| | `/api/v1/knowledge-graph/stats` | GET | KG statistics |
+| | `/api/v1/knowledge-graph/expanded-nodes` | GET | Expanded-node lifecycle state |
+| Memory | `/api/v1/memory/stats` | GET | Episode + Claw memory stats |
+| Settings | `/api/v1/settings` | GET / POST | Runtime config |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 # DocThinker
 
-**自进化知识图谱 · 长短期记忆 · 结构化推理**
+**Agentic Memory Framework · 自进化知识图谱 · 文档推理**
 
 *语言记录了认知过程的结果，而认知过程包含感知，经验，推理的过程。*
 
@@ -26,12 +26,9 @@
 
 <br>
 
-**DocThinker** 是一个文档驱动的 RAG 系统，从上传文档中构建自进化的知识图谱。与传统"检索-LLM 回复"路线不同，DocThinker 将知识视为**动态的图谱**。
+**DocThinker** 是一个面向文档理解的 agentic memory 框架。它把文档、对话轮次、检索轨迹和图谱扩展转化为可召回、可推理、可巩固的多层记忆系统。
 
-### 🎬 探索教程!!
-
-<!-- TODO: 替换为演示视频 -->
-> [▶️ **在 YouTube 观看教程**](#) | [🚀 **在 HuggingFace Space 体验**](#) | [📝 **Colab 教程**](#)
+与传统“检索后回答”的 RAG 管线不同，DocThinker 将知识视为持续演化的记忆底座：session-scoped 知识图谱承担语义记忆，Claw 承担分层对话记忆，Neuro Memory 承担情节类比记忆，KG expansion 则维护可被使用和晋升的图谱假设。
 
 ---
 
@@ -42,12 +39,12 @@
   - [1. Web UI & 服务端](#1-web-ui--服务端)
   - [2. Python API 极简调用](#2-python-api-极简调用)
 - [🧬 核心贡献 (Key Contributions)](#-核心贡献)
-  - [1. Test-Time Scaling 与智能体记忆](#1--test-time-scaling-与智能体记忆)
-  - [2. 双路径图谱自扩张](#2--双路径-kg-自扩展)
-  - [3. 自进化知识图谱](#3--自进化知识图谱)
-  - [4. 多 Agent 协同进化](#4--多-agent-协同进化)
-  - [5. 分层对话记忆 (Claw)](#5--分层对话记忆claw)
-  - [6. SPARQL 链式思维推理](#6--sparql-链式思维推理)
+  - [1. Agentic Memory Core](#1--agentic-memory-core)
+  - [2. 会话级知识图谱](#2--会话级知识图谱)
+  - [3. 自进化 KG 扩展](#3--自进化-kg-扩展)
+  - [4. 分层对话记忆 (Claw)](#4--分层对话记忆-claw)
+  - [5. 情节类比记忆](#5--情节类比记忆)
+  - [6. 多模态检索信号](#6--多模态检索信号)
 - [💡 使用场景 (Use Cases)](#-使用场景)
 - [⚡ 查询模式与文档处理](#-查询模式)
 - [📡 API 参考](#-api-参考)
@@ -111,11 +108,8 @@ async def main():
     # 3. 摄入文档 (解析 + 构建知识图谱)
     await dt.process_document_complete("your_document.pdf")
     
-    # 4. 触发 Test-Time Scaling (KG 后台自习循环)，增强图谱密度与经验记忆
-    await dt.run_self_study_loop(max_rounds=5)
-    
-    # 5. 深度图谱推理查询
-    response = await dt.aquery("这篇文档的核心思想是什么？", mode="deep")
+    # 4. 查询会话知识图谱
+    response = await dt.aquery("这篇文档的核心思想是什么？", mode="mix")
     print(response)
 
 asyncio.run(main())
@@ -125,44 +119,49 @@ asyncio.run(main())
 
 ## 🧬 核心贡献
 
-DocThinker 将庞大的管线拆分为自主的智能体，并引入了图谱认知推理。
+DocThinker 将检索和记忆组织成一个面向 agent 的框架，而不是把记忆逻辑分散在 API handler 里。
 
 <div align="center">
 <img src="docs/assets/pipeline.png" alt="DocThinker Pipeline" width="820" />
 <p><b>图 1.</b> DocThinker 端到端管线 — 从文档输入到知识图谱构建、分层记忆管理、混合检索推理，最终输出并反馈回图谱。</p>
 </div>
 
-### 1. 🧠 Test-Time Scaling 与智能体记忆
-在文档写入和用户查询之间，系统会插入**后台自习循环 (Test-Time Scaling on KG)**：LLM 会对已有 KG 自主进行“出题 → 检索答题 → 归纳演绎”，并将产生的新知识和方法论经验（`entity_type="experience"`）作为智能体记忆写回图谱中。这通过不断的演绎推理，在不增加用户等待时间的情况下，大幅提升了知识图谱的信息密度和系统的推理能力。
+### 1. 🧠 Agentic Memory Core
+`docthinker.memory_core.AgentMemoryCore` 是当前稳定的 agent 记忆门面。回答生成前，`recall()` 会合并：
 
-### 2. 🔀 双路径 KG 自扩展
+* Claw 的 working/core/archive 对话记忆。
+* Neuro Memory 的相似情节与类比 episode。
+* KG 扩展节点匹配结果和强制检索指令。
+
+回答生成后，`after_response()` 会把本轮问答巩固回记忆层，写入 chat episode，可选回写到图谱，并推动有用的扩展节点晋升。
+
+### 2. 🧩 会话级知识图谱
+每个 session 拥有自己的 GraphCore 知识图谱和文档状态。上传文件会在对应 session 内解析、写入和查询，从而隔离用户上下文，同时允许每个会话的图谱持续生长。
+
+### 3. 🔀 自进化 KG 扩展
 扩展以两条互补路径执行：
 * **A — 聚类驱动：** HDBSCAN 聚类实体 embedding → LLM 生成聚类摘要 → 基于摘要主题扩展新实体。
 * **B — Top-N 多角度：** 取连接度最高的 50 个节点，从 6 个认知维度（层级、因果、类比、对立、时序、应用）扩展。
 
-### 3. 🔄 自进化知识图谱
-扩展的新节点不会直接成为正式知识——它们先以 `candidate` 身份进入图谱。只有当用户在实际对话中反复用到某个节点时，该节点的使用计数和评分才会累积，满足条件后晋升为正式节点。
-
-### 4. 🤖 多 Agent 协同进化
-DocThinker 将传统 RAG 的单一管线拆分为三个专职 Agent：
-* **Retrieval Agent:** 负责最大化检索命中率。
-* **Extraction Agent:** 负责最大化信息抽取覆盖率。
-* **Answering Agent:** 负责生成最终回答并触发节点反馈。
+扩展节点不会直接成为正式知识。它们先作为候选节点进入生命周期管理，在 query-time 被匹配，并在回答中反复产生有效使用后晋升为正式图谱节点。
 
 <div align="center">
-<img src="docs/assets/multi_agent_evolution.png" alt="多 Agent 协同进化架构" width="820" />
-<p><sub><b>图 2.</b> DocThinker 多 Agent 协同进化架构。</sub></p>
+<img src="docs/assets/multi_agent_evolution.png" alt="记忆与图谱反馈架构" width="820" />
+<p><sub><b>图 2.</b> 记忆与图谱反馈闭环。</sub></p>
 </div>
 
-### 5. 🗃️ 分层对话记忆 (Claw)
-受 [OpenClaw / Letta](https://github.com/letta-ai/letta) 启发，Claw 实现了**三层记忆层级**（热、温、冷），实现无界对话长度。
+### 4. 🗃️ 分层对话记忆 (Claw)
+Claw 提供三层对话记忆：热层 working memory、温层核心摘要、冷层语义归档，用于支撑长时间会话。
 
-### 6. 🧠 SPARQL 链式思维推理
-复杂查询在回答前被内部分解为 **SPARQL 风格的三元组模式链**。LLM 通过共享变量链在 KG 上下文中绑定变量。
+### 5. 🧠 情节类比记忆
+Neuro Memory 将对话和文档经历存为 episode，并在后续问题中检索相似情节作为类比线索。这些结果通过 `episodic_matches` 暴露，并作为推理提示注入，而不是直接当作事实来源。
 
 <div align="center">
-<img src="docs/assets/sparql_cot.png" alt="SPARQL CoT 推理" width="680" />
+<img src="docs/assets/sparql_cot.png" alt="结构化推理" width="680" />
 </div>
+
+### 6. 🖼️ 多模态检索信号
+DocThinker 会记录文档解析出的图片资产，并在 deep UI 查询中激活相关视觉证据。
 
 ---
 
@@ -179,7 +178,7 @@ DocThinker 将传统 RAG 的单一管线拆分为三个专职 Agent：
 </td>
 <td width="50%" valign="top">
 
-> *"深度模式对话 — SPARQL CoT 推理 + 分层记忆"*
+> *"深度模式对话 — 情节记忆 + KG 扩展匹配 + 分层记忆"*
 
 <img src="docs/assets/usecase_chat.gif" width="100%"/>
 
@@ -191,22 +190,22 @@ DocThinker 将传统 RAG 的单一管线拆分为三个专职 Agent：
 
 ## ⚡ 查询模式
 
-| 模式 | 策略 | 延迟 | 深度 |
-|------|------|------|------|
-| **快速** | 向量相似度 | ~1 s | 浅 |
-| **标准** | 混合 KG + 向量 + 重排序 | ~3 s | 中 |
-| **深度** | SPARQL CoT + 扩散激活 + 情节记忆 + 扩展匹配 + 查询后反馈 | ~8 s | 完整 |
+| 模式 | UI 映射 | 策略 | 深度 |
+|------|---------|------|------|
+| **快速** | `naive` | 轻量检索，关闭 rerank | 浅 |
+| **标准** | `local` | 会话 KG 检索 + rerank | 中 |
+| **深度** | `mix` | KG + 向量检索、Claw 记忆、情节类比、扩展节点匹配、图像激活、查询后巩固 | 完整 |
 
 <details>
 <summary><b>深度模式管线（7 步）</b></summary>
 
-1. 通过扩散激活从情节记忆中检索类比情节。
-2. 将扩展候选节点与查询匹配（词重叠 + 嵌入相似度）。
-3. 将命中的扩展节点作为强制检索指令注入。
-4. 将查询分解为 SPARQL CoT 三元组模式链。
-5. 混合 KG + 向量检索并启用扩散激活。
-6. LLM 使用完整上下文和变量绑定生成回答。
-7. 查询后反馈：验证扩展节点、存储情节、共激活链接、更新 Claw 记忆层。
+1. Claw 召回 working/core/archive 对话记忆。
+2. Neuro Memory 检索相似 episode 作为类比线索。
+3. ExpandedNodeManager 将候选扩展节点与查询匹配。
+4. `AgentMemoryCore.recall()` 合并为统一 retrieval instruction。
+5. GraphCore 执行 KG + 向量混合检索。
+6. LLM 基于问题、检索结果和记忆上下文生成回答。
+7. `AgentMemoryCore.after_response()` 写入 episode、更新 Claw，并推动扩展节点生命周期。
 
 </details>
 
@@ -223,19 +222,20 @@ DocThinker 将传统 RAG 的单一管线拆分为三个专职 Agent：
 
 | 类别 | 端点 | 方法 | 说明 |
 |------|------|------|------|
-| 会话 | `/sessions` | GET / POST | 列出 / 创建会话 |
-| | `/sessions/{id}/history` | GET | 聊天历史 |
-| | `/sessions/{id}/files` | GET | 已上传文件 |
-| 上传 | `/ingest` | POST | 上传 PDF / TXT |
-| | `/ingest/stream` | POST | 流式文本上传 |
-| 查询 | `/query/stream` | POST | SSE 流式查询 |
-| | `/query` | POST | 非流式查询 |
-| KG | `/knowledge-graph/data` | GET | 可视化节点/边 |
-| | `/knowledge-graph/expand` | POST | 触发双路径扩展 |
-| | `/knowledge-graph/stats` | GET | KG 统计 |
-| 记忆 | `/memory/stats` | GET | 情节 + Claw 记忆统计 |
-| | `/memory/consolidate` | POST | 触发情节固化 |
-| 设置 | `/settings` | GET / POST | 运行时配置 |
+| 会话 | `/api/v1/sessions` | GET / POST | 列出 / 创建会话 |
+| | `/api/v1/sessions/{id}/history` | GET | 聊天历史 |
+| | `/api/v1/sessions/{id}/files` | GET | 已上传文件 |
+| 上传 | `/api/v1/ingest` | POST | 上传 PDF / TXT |
+| | `/api/v1/ingest/stream` | POST | 流式文本上传 |
+| 查询 | `/api/v1/query/stream` | POST | SSE 流式查询 |
+| | `/api/v1/query` | POST | 非流式查询 |
+| | `/api/v1/query/text` | POST | 非流式查询别名 |
+| KG | `/api/v1/knowledge-graph/data` | GET | 可视化节点/边 |
+| | `/api/v1/knowledge-graph/expand` | POST | 触发 KG 扩展 |
+| | `/api/v1/knowledge-graph/stats` | GET | KG 统计 |
+| | `/api/v1/knowledge-graph/expanded-nodes` | GET | 扩展节点生命周期 |
+| 记忆 | `/api/v1/memory/stats` | GET | 情节 + Claw 记忆统计 |
+| 设置 | `/api/v1/settings` | GET / POST | 运行时配置 |
 
 </details>
 
@@ -244,8 +244,8 @@ DocThinker 将传统 RAG 的单一管线拆分为三个专职 Agent：
 
 | 目录 | 说明 |
 |------|------|
-| `docthinker/` | 核心：PDF 解析、KG 构建、查询路由、双路径扩展（`kg_expansion/`）、自动思考（`auto_thinking/`）、HyperGraphRAG（`hypergraph/`）、服务端（`server/`）、UI（`ui/`）。 |
-| `graphcore/` | 图 RAG 引擎：KG 存储（NetworkX / FAISS / Qdrant / PG）、SPARQL CoT 提示词、实体抽取、重排序。 |
+| `docthinker/` | 核心：PDF 解析、KG 构建、agentic memory 门面（`memory_core/`）、查询路由、KG 扩展（`kg_expansion/`）、自动思考（`auto_thinking/`）、HyperGraphRAG（`hypergraph/`）、服务端（`server/`）、UI（`ui/`）。 |
+| `graphcore/` | 图 RAG 引擎：KG 存储（NetworkX / FAISS / Qdrant / PG）、实体抽取、混合检索、重排序。 |
 | `neuro_memory/` | 情节记忆：扩散激活、情节存储、类比检索、记忆固化。 |
 | `claw/` | 分层记忆：热层（工作记忆）、温层（核心 / MEMORY.md）、冷层（语义档案）。 |
 | `config/` | `settings.yaml` — PDF、记忆、检索、认知参数。 |

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,8 +1,10 @@
 ﻿# PROJECT_STRUCTURE
 
-## 1. 当前唯一主线
+## 1. 当前主线定位
 
-当前仓库只维护以下主线：
+当前仓库主线定位为 **Agentic Memory Framework**：将文档、对话和推理轨迹转化为可检索、可巩固、可自我演化的多层记忆系统。
+
+当前保留以下运行入口：
 - `run_ui.py` -> `docthinker/ui/app.py`（Flask UI）
 - `uvicorn docthinker.server.app:app`（FastAPI 后端）
 
@@ -20,6 +22,7 @@
 ## 3. docthinker 子结构
 
 - `docthinker/server/app.py`：后端应用入口与生命周期初始化
+- `docthinker/memory_core/`：Agentic Memory 统一门面，对外提供 recall / after-response consolidation
 - `docthinker/server/routers/`：API 路由
   - `query.py`：查询与回答
   - `ingest.py`：文档/文本入库
@@ -31,15 +34,20 @@
 - `docthinker/auto_thinking/`：自动思考与多步推理
 - `docthinker/hypergraph/`：超图 RAG
 - `docthinker/kg_expansion/`：KG 扩展模块
+- `claw/`：热/温/冷三层对话记忆
+- `neuro_memory/`：情节记忆、扩散激活、类比检索
+- `graphcore/`：语义记忆与实体关系检索底座
 
 ## 4. 关键数据流
 
 1. UI 将请求转发到 `/api/v1/*`
-2. 后端在 `lifespan` 初始化 RAG + MemoryEngine
-3. `query` 路由调用编排器与记忆引擎
-4. `graph` 路由负责图谱数据、记忆统计、KG扩展
+2. 后端在 `lifespan` 初始化 session-scoped RAG、Claw、Neuro Memory、KG 扩展能力
+3. `query` 路由通过 `memory_core.AgentMemoryCore.recall()` 组装 agent 记忆上下文
+4. `DocThinker/GraphCore` 作为 recall backend 生成答案
+5. 答案返回后通过 `AgentMemoryCore.after_response()` 触发记忆巩固、可选对话回写、扩展节点晋升
+6. `graph` 路由负责图谱数据、记忆统计、KG 扩展调试与人工操作
 
 ## 5. 清理结果
 
-- 仅保留 `docthinker + graphcore + neuro_memory` 主线。
+- 仅保留 `docthinker + graphcore + claw + neuro_memory` 主线。
 - 旧入口与旧模块已移除，不再维护兼容分支。

--- a/docs/SYSTEM_FLOW_GUIDE.md
+++ b/docs/SYSTEM_FLOW_GUIDE.md
@@ -10,28 +10,36 @@ UI 侧页面通过 `docthinker/ui/app.py` 代理调用后端 `api/v1`。
 ## 2. 后端初始化流程（`docthinker/server/app.py`）
 
 1. 加载 providers/settings
-2. 初始化 `DocThinker` 与 GraphCore
-3. 初始化 `MemoryEngine`（`neuro_memory`）
+2. 初始化 `DocThinker` 与 GraphCore，作为语义记忆 / KG recall backend
+3. 初始化 `MemoryEngine`（`neuro_memory`），用于情节记忆、类比检索、扩散激活
 4. 初始化 `IngestionService`
-5. 初始化 `HybridRAGOrchestrator` + `HyperGraphRAG`
-6. 注册所有 `/api/v1/*` 路由
+5. 初始化 Claw 三层对话记忆（working/core/archive）
+6. 初始化 `HybridRAGOrchestrator` + `HyperGraphRAG`（实验性复杂查询路径）
+7. 注册所有 `/api/v1/*` 路由
 
 ## 3. 查询流程
 
 1. 前端调用 `/api/v1/query` 或 `/api/v1/query/text`
-2. 查询路由进入编排器（复杂度分类、分解、检索、聚合）
-3. 同步使用 `neuro_memory` 做：
-   - observation 写入
-   - analogy 检索
-   - co-activation 记录
-4. 返回最终答案与相关上下文
+2. 查询路由调用 `AgentMemoryCore.recall()`：
+   - Claw 注入对话工作记忆、核心摘要和语义归档片段
+   - Neuro Memory 检索相似情节与类比 episode，形成 episodic analogy context
+   - KG 扩展节点执行 query-time match，并生成强制检索指令
+   - 输出统一 `RecallBundle` 与 `MemoryTrace`
+3. `DocThinker/GraphCore` 根据原始问题 + memory instruction 执行检索生成
+4. 返回答案、sources、memory trace、expanded matches
+5. 后台调用 `AgentMemoryCore.after_response()`：
+   - 更新 Claw 记忆层
+   - 将本轮问答写入 Neuro Memory episode store，供后续类比召回
+   - 可选将对话 turn 写回 KG
+   - 根据回答使用情况推进 expanded node candidate -> active -> promoted
 
 ## 4. 入库流程
 
 1. 前端上传文件到 UI 代理
 2. UI 代理转发到 `/api/v1/ingest`
-3. `IngestionService` 处理并写入 GraphCore
-4. 会话/全局存储按配置同步
+3. `IngestionService` 处理并写入 session-scoped GraphCore
+4. 本地 KG/KB/snapshot 更新
+5. 后台触发密度聚类、潜在边发现、KG self-study
 
 ## 5. KG 扩展流程
 
@@ -39,10 +47,13 @@ UI 侧页面通过 `docthinker/ui/app.py` 代理调用后端 `api/v1`。
 2. `docthinker/kg_expansion/expander.py` 基于现有图谱摘要生成候选节点
 3. 执行去重与筛选
 4. 将扩展节点写入图存储，并打标 `is_expanded=1`
+5. `ExpandedNodeManager` 记录 candidate 生命周期；后续 query 使用和回答采纳会推动晋升
 
 ## 6. 关键文件映射
 
+- 记忆门面：`docthinker/memory_core/core.py`
 - 查询：`docthinker/server/routers/query.py`
 - 图谱：`docthinker/server/routers/graph.py`
-- 记忆：`neuro_memory/engine.py`
+- 对话记忆：`claw/memory_manager.py`
+- 情节记忆：`neuro_memory/engine.py`
 - 扩展：`docthinker/kg_expansion/expander.py`

--- a/docthinker/__init__.py
+++ b/docthinker/__init__.py
@@ -1,11 +1,8 @@
-from .core import DocThinker as DocThinker
-from .config import DocThinkerConfig as DocThinkerConfig
-from .auto_thinking import (
-    HybridRAGOrchestrator,
-    ComplexityClassifier,
-    ComplexityVote,
-    VLMClient,
-)
+"""Public package exports for DocThinker.
+
+Imports are resolved lazily so lightweight subpackages such as
+``docthinker.memory_core`` do not pull in server/runtime dependencies.
+"""
 
 __version__ = "1.2.8"
 __author__ = "Zirui Guo"
@@ -18,4 +15,32 @@ __all__ = [
     "ComplexityClassifier",
     "ComplexityVote",
     "VLMClient",
+    "AgentMemoryCore",
+    "RecallBundle",
+    "MemoryTrace",
 ]
+
+
+def __getattr__(name):
+    if name == "DocThinker":
+        from .core import DocThinker
+
+        return DocThinker
+    if name == "DocThinkerConfig":
+        from .config import DocThinkerConfig
+
+        return DocThinkerConfig
+    if name in {
+        "HybridRAGOrchestrator",
+        "ComplexityClassifier",
+        "ComplexityVote",
+        "VLMClient",
+    }:
+        from . import auto_thinking
+
+        return getattr(auto_thinking, name)
+    if name in {"AgentMemoryCore", "RecallBundle", "MemoryTrace"}:
+        from . import memory_core
+
+        return getattr(memory_core, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/docthinker/memory_core/__init__.py
+++ b/docthinker/memory_core/__init__.py
@@ -1,0 +1,10 @@
+"""Agentic memory core facade.
+
+This package is the stable entrypoint agents should use for memory work.
+It wraps the current Claw, neuro/episode, and KG expansion pieces without
+forcing a large rewrite of the existing RAG stack.
+"""
+
+from .core import AgentMemoryCore, RecallBundle, MemoryTrace
+
+__all__ = ["AgentMemoryCore", "RecallBundle", "MemoryTrace"]

--- a/docthinker/memory_core/core.py
+++ b/docthinker/memory_core/core.py
@@ -1,0 +1,444 @@
+"""Unified facade for agentic memory behavior.
+
+The first version intentionally wraps existing systems instead of replacing
+them:
+- Claw provides conversational working/core/archive memory.
+- Neuro memory provides episodic analogies and activation traces.
+- Expanded KG nodes provide evolving semantic hypotheses.
+- GraphCore receives promoted expansion nodes after repeated use.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+
+_log = logging.getLogger("docthinker.memory_core")
+
+
+def _extract_entities_from_text(text: str, max_entities: int = 12) -> List[str]:
+    try:
+        from docthinker.kg_expansion import extract_entities_from_text
+
+        return extract_entities_from_text(text, max_entities=max_entities)
+    except Exception:
+        source = str(text or "")
+        entities: List[str] = []
+        seen: set[str] = set()
+        for pattern in (r"[\u4e00-\u9fff]{2,10}", r"\b[A-Za-z][A-Za-z0-9_\-]{2,32}\b"):
+            for match in re.finditer(pattern, source):
+                name = match.group(0).strip()
+                if name and name not in seen:
+                    seen.add(name)
+                    entities.append(name)
+                    if len(entities) >= max_entities:
+                        return entities
+        return entities
+
+
+@dataclass
+class MemoryTrace:
+    """Small, serializable trace of memory work done for one turn."""
+
+    memory_mode: str = "session"
+    memory_hits: int = 0
+    episodic_hits: int = 0
+    expanded_hits: int = 0
+    memory_context_injected: bool = False
+    retrieval_instruction_applied: bool = False
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def format_for_response(self, mode: str = "") -> str:
+        lines: List[str] = [f"memory_mode: {self.memory_mode}"]
+        if self.retrieval_instruction_applied:
+            lines.append("retrieval_instruction: provided")
+        lines.append(f"memory_hits: {self.memory_hits}")
+        lines.append(f"episodic_hits: {self.episodic_hits}")
+        lines.append(f"expanded_hits: {self.expanded_hits}")
+        if mode:
+            lines.append(f"mode: {mode}")
+        if self.memory_context_injected:
+            lines.append("memory_context: injected")
+        return "\n".join(lines)
+
+
+@dataclass
+class RecallBundle:
+    """Memory context prepared before answer generation."""
+
+    retrieval_instruction: str = ""
+    memory_summaries: List[Dict[str, Any]] = field(default_factory=list)
+    episodic_matches: List[Dict[str, Any]] = field(default_factory=list)
+    expanded_matches: List[Dict[str, Any]] = field(default_factory=list)
+    trace: MemoryTrace = field(default_factory=MemoryTrace)
+
+
+class AgentMemoryCore:
+    """Facade that presents memory as a coherent agent-facing subsystem."""
+
+    def __init__(
+        self,
+        *,
+        get_claw_manager: Callable[[Optional[str]], Optional[Any]],
+        get_expanded_node_manager: Callable[[Optional[str]], Optional[Any]],
+        get_session_rag: Callable[[Optional[str]], Awaitable[Any]],
+        get_memory_engine: Optional[Callable[[Optional[str]], Optional[Any]]] = None,
+        ingest_chat_turn: Optional[
+            Callable[[str, str, Optional[str], Optional[float]], Awaitable[None]]
+        ] = None,
+        chat_turn_ingest_enabled: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self.get_claw_manager = get_claw_manager
+        self.get_memory_engine = get_memory_engine or (lambda _sid: None)
+        self.get_expanded_node_manager = get_expanded_node_manager
+        self.get_session_rag = get_session_rag
+        self.ingest_chat_turn = ingest_chat_turn
+        self.chat_turn_ingest_enabled = chat_turn_ingest_enabled or (lambda: False)
+
+    @staticmethod
+    def _merge_instructions(*instructions: Optional[str]) -> str:
+        parts: List[str] = []
+        for instruction in instructions:
+            text = str(instruction or "").strip()
+            if text:
+                parts.append(text)
+        return "\n\n".join(parts).strip()
+
+    @staticmethod
+    def _format_episodic_instruction(matches: Sequence[Dict[str, Any]]) -> str:
+        if not matches:
+            return ""
+        lines = [
+            "## 情节记忆与类比参考",
+            "以下是 agent 过往经历中与当前问题相似的片段。请将其作为类比线索，而不是直接事实来源。",
+            "",
+        ]
+        for item in matches[:5]:
+            summary = str(item.get("summary") or "").strip()
+            reason = str(item.get("reason") or "").strip()
+            score = float(item.get("score") or 0.0)
+            lines.append(f"- [{score:.2f}] {summary[:240]}")
+            if reason:
+                lines.append(f"  关联原因: {reason[:160]}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _serialize_episode_match(raw: Any) -> Optional[Dict[str, Any]]:
+        try:
+            episode, score, reason = raw
+        except Exception:
+            return None
+        summary = str(getattr(episode, "summary", "") or "").strip()
+        if not summary:
+            return None
+        return {
+            "episode_id": str(getattr(episode, "episode_id", "") or ""),
+            "summary": summary,
+            "score": round(float(score or 0.0), 4),
+            "reason": str(reason or ""),
+            "source_type": str(getattr(episode, "source_type", "") or ""),
+            "concepts": list(getattr(episode, "concepts", []) or [])[:8],
+            "entity_ids": list(getattr(episode, "entity_ids", []) or [])[:8],
+        }
+
+    async def recall(
+        self,
+        *,
+        session_id: Optional[str],
+        query: str,
+        base_instruction: str = "",
+        mode: str = "",
+        enable_thinking: bool = False,
+        enable_expanded_matching: bool = True,
+        expanded_top_k: int = 2,
+        expanded_min_score: float = 0.2,
+        skip_memory: bool = False,
+    ) -> RecallBundle:
+        """Prepare memory context and KG hypothesis matches for one query."""
+
+        trace = MemoryTrace()
+        merged_instruction = str(base_instruction or "").strip()
+        memory_summaries: List[Dict[str, Any]] = []
+        episodic_matches: List[Dict[str, Any]] = []
+        expanded_matches: List[Dict[str, Any]] = []
+
+        if skip_memory:
+            trace.retrieval_instruction_applied = bool(merged_instruction)
+            return RecallBundle(
+                retrieval_instruction=merged_instruction,
+                memory_summaries=memory_summaries,
+                episodic_matches=episodic_matches,
+                expanded_matches=expanded_matches,
+                trace=trace,
+            )
+
+        if enable_thinking:
+            claw_mgr = self.get_claw_manager(session_id)
+            if claw_mgr:
+                try:
+                    claw_context = await claw_mgr.build_memory_context(
+                        query,
+                        enable_archive=True,
+                    )
+                    if claw_context:
+                        merged_instruction = self._merge_instructions(
+                            merged_instruction,
+                            claw_context,
+                        )
+                        memory_summaries = [{"source": "claw", "injected": True}]
+                        trace.memory_context_injected = True
+                        trace.events.append({
+                            "type": "memory_context",
+                            "source": "claw",
+                            "chars": len(claw_context),
+                        })
+                except Exception as exc:
+                    _log.warning("[recall] claw context failed: %s", exc)
+
+            memory_engine = self.get_memory_engine(session_id)
+            if memory_engine:
+                try:
+                    raw_matches = await memory_engine.retrieve_analogies(
+                        query,
+                        top_k=5,
+                        then_spread=True,
+                        spread_top_k=3,
+                    )
+                    for raw in raw_matches:
+                        match = self._serialize_episode_match(raw)
+                        if match:
+                            episodic_matches.append(match)
+                    if episodic_matches:
+                        episodic_instruction = self._format_episodic_instruction(
+                            episodic_matches,
+                        )
+                        merged_instruction = self._merge_instructions(
+                            merged_instruction,
+                            episodic_instruction,
+                        )
+                        memory_summaries.append({
+                            "source": "neuro_memory",
+                            "kind": "episodic_analogy",
+                            "count": len(episodic_matches),
+                        })
+                        trace.memory_context_injected = True
+                        trace.events.append({
+                            "type": "episodic_recall",
+                            "source": "neuro_memory",
+                            "count": len(episodic_matches),
+                        })
+                except Exception as exc:
+                    _log.warning("[recall] episodic recall failed: %s", exc)
+
+        if enable_expanded_matching:
+            expanded_manager = self.get_expanded_node_manager(session_id)
+            if expanded_manager:
+                expanded_matches = expanded_manager.match_nodes(
+                    query=query,
+                    top_k=max(1, int(expanded_top_k)),
+                    min_score=max(0.0, float(expanded_min_score)),
+                )
+                if expanded_matches:
+                    expanded_manager.mark_hits([
+                        str(match.get("entity") or "")
+                        for match in expanded_matches
+                    ])
+                    expanded_instruction = expanded_manager.build_forced_instruction(
+                        expanded_matches,
+                        limit=min(2, max(1, int(expanded_top_k))),
+                    )
+                    merged_instruction = self._merge_instructions(
+                        merged_instruction,
+                        expanded_instruction,
+                    )
+                    trace.events.append({
+                        "type": "expanded_match",
+                        "count": len(expanded_matches),
+                    })
+
+        trace.memory_hits = len(memory_summaries)
+        trace.episodic_hits = len(episodic_matches)
+        trace.expanded_hits = len(expanded_matches)
+        trace.retrieval_instruction_applied = bool(merged_instruction)
+        return RecallBundle(
+            retrieval_instruction=merged_instruction,
+            memory_summaries=memory_summaries,
+            episodic_matches=episodic_matches,
+            expanded_matches=expanded_matches,
+            trace=trace,
+        )
+
+    async def after_response(
+        self,
+        *,
+        session_id: Optional[str],
+        question: str,
+        answer: str,
+        matched_expanded: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Consolidate memories after a response has been produced."""
+
+        if not session_id or not answer:
+            return {"updated": False}
+
+        t0 = time.time()
+        result: Dict[str, Any] = {
+            "updated": True,
+            "claw_updated": False,
+            "episode_added": False,
+            "chat_turn_ingested": False,
+            "expanded_promoted": [],
+        }
+
+        claw_mgr = self.get_claw_manager(session_id)
+        if claw_mgr:
+            try:
+                await claw_mgr.post_query_update(question, answer, session_id, time.time())
+                result["claw_updated"] = True
+            except Exception as exc:
+                _log.warning("[after_response] claw update failed: %s", exc)
+
+        memory_engine = self.get_memory_engine(session_id)
+        if memory_engine:
+            try:
+                concepts = _extract_entities_from_text(
+                    f"{question}\n{answer}",
+                    max_entities=12,
+                )
+                episode = await memory_engine.add_observation(
+                    summary=f"User asked: {question}\nAssistant answered: {answer[:500]}",
+                    key_points=[question, answer[:300]],
+                    concepts=concepts,
+                    entity_ids=concepts,
+                    source_type="chat",
+                    session_id=session_id,
+                    timestamp=time.time(),
+                )
+                if episode is not None:
+                    result["episode_added"] = True
+                    result["episode_id"] = getattr(episode, "episode_id", "")
+            except Exception as exc:
+                _log.warning("[after_response] episode add failed: %s", exc)
+
+        if self.ingest_chat_turn and self.chat_turn_ingest_enabled():
+            try:
+                await self.ingest_chat_turn(question, answer, session_id, time.time())
+                result["chat_turn_ingested"] = True
+            except Exception as exc:
+                _log.warning("[after_response] chat turn ingest failed: %s", exc)
+
+        if matched_expanded:
+            try:
+                promoted = await self._promote_expanded_nodes(
+                    session_id=session_id,
+                    answer=answer,
+                    matched_nodes=matched_expanded,
+                )
+                result["expanded_promoted"] = promoted
+            except Exception as exc:
+                _log.warning("[after_response] expanded promotion failed: %s", exc)
+
+        result["elapsed_seconds"] = round(time.time() - t0, 3)
+        return result
+
+    async def _promote_expanded_nodes(
+        self,
+        *,
+        session_id: str,
+        answer: str,
+        matched_nodes: Sequence[Dict[str, Any]],
+    ) -> List[str]:
+        manager = self.get_expanded_node_manager(session_id)
+        if manager is None:
+            return []
+
+        entities = _extract_entities_from_text(answer, max_entities=12)
+        usage = manager.record_response_usage(
+            answer=answer,
+            matches=matched_nodes,
+            attached_entities=entities,
+        )
+        promoted_names = [
+            str(name).strip()
+            for name in (usage.get("promoted") or [])
+            if str(name).strip()
+        ]
+        if not promoted_names:
+            return []
+
+        session_rag = await self.get_session_rag(session_id)
+        graphcore = getattr(session_rag, "graphcore", None)
+        if graphcore is None:
+            return []
+        graph = graphcore.chunk_entity_relation_graph
+        changed = False
+
+        for name in promoted_names:
+            record = manager.get(name)
+            if not record:
+                continue
+            roots = [
+                str(root).strip()
+                for root in (record.get("root_ids") or [])
+                if str(root).strip()
+            ]
+
+            await graph.upsert_node(
+                name,
+                {
+                    "entity_id": name,
+                    "entity_type": "concept",
+                    "description": record.get("reason") or record.get("description") or name,
+                    "source_id": "promoted_expansion",
+                    "is_expanded": "0",
+                },
+            )
+            changed = True
+
+            for ent in entities[:8]:
+                if not ent or ent == name:
+                    continue
+                await graph.upsert_node(
+                    ent,
+                    {
+                        "entity_id": ent,
+                        "entity_type": "concept",
+                        "description": f"Extracted from answer for expansion node {name}",
+                        "source_id": "answer_entity",
+                    },
+                )
+                await graph.upsert_edge(
+                    name,
+                    ent,
+                    {
+                        "keywords": "co_mentioned",
+                        "description": f"Assistant answer associated {name} with {ent}",
+                        "source_id": "answer_entity",
+                    },
+                )
+                changed = True
+
+            for root in roots[:6]:
+                if not root or root == name:
+                    continue
+                await graph.upsert_edge(
+                    name,
+                    root,
+                    {
+                        "keywords": "expanded_from_root",
+                        "description": f"Promoted expansion node linked to root node {root}",
+                        "source_id": "llm_expansion",
+                    },
+                )
+                changed = True
+
+        if changed and hasattr(graph, "index_done_callback"):
+            try:
+                await graph.index_done_callback(force_save=True)
+            except TypeError:
+                await graph.index_done_callback()
+
+        return promoted_names

--- a/docthinker/server/routers/query.py
+++ b/docthinker/server/routers/query.py
@@ -11,8 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from fastapi.responses import StreamingResponse
 
-from docthinker.kg_expansion import ExpandedNodeManager, extract_entities_from_text
-from ..memory import get_session_claw_manager
+from docthinker.kg_expansion import ExpandedNodeManager
+from docthinker.memory_core import AgentMemoryCore
+from ..memory import get_session_claw_manager, get_session_memory_engine
 from ..schemas import MultiDocumentQueryRequest, QueryRequest
 from ..state import state
 
@@ -70,21 +71,27 @@ def _get_pending_session_files(session_id: Optional[str]) -> List[Dict[str, Any]
     return pending
 
 
-def _format_thinking_process(details: Dict[str, Any], meta: Dict[str, Any]) -> str:
-    lines: List[str] = []
-    if meta.get("memory_mode"):
-        lines.append(f"memory_mode: {meta['memory_mode']}")
-    if meta.get("retrieval_instruction"):
-        lines.append("retrieval_instruction: provided")
-    if details.get("memory_hits") is not None:
-        lines.append(f"memory_hits: {details['memory_hits']}")
-    if details.get("expanded_hits") is not None:
-        lines.append(f"expanded_hits: {details['expanded_hits']}")
-    if details.get("mode"):
-        lines.append(f"mode: {details['mode']}")
-    if details.get("memory_context_injected"):
-        lines.append("memory_context: injected")
-    return "\n".join(lines)
+def _get_recent_conversation_history(
+    session_id: Optional[str],
+    *,
+    limit: int = 6,
+) -> List[Dict[str, str]]:
+    if not session_id or not state.session_manager:
+        return []
+    try:
+        raw_history = state.session_manager.get_history(session_id)
+    except Exception:
+        return []
+
+    conversation_history: List[Dict[str, str]] = []
+    for msg in raw_history[-max(1, int(limit)):]:
+        if not isinstance(msg, dict):
+            continue
+        conversation_history.append({
+            "role": str(msg.get("role") or "user"),
+            "content": str(msg.get("content") or ""),
+        })
+    return conversation_history
 
 
 def _build_sources_from_details(details: Any, evidence: Any = None) -> List[Dict[str, Any]]:
@@ -411,101 +418,15 @@ def _get_expanded_node_manager(session_id: Optional[str]) -> Optional[ExpandedNo
         return manager
 
 
-def _merge_retrieval_instruction(*instructions: Optional[str]) -> str:
-    parts = []
-    for ins in instructions:
-        text = str(ins or "").strip()
-        if text:
-            parts.append(text)
-    return "\n\n".join(parts).strip()
-
-
-async def _promote_expanded_nodes_in_background(
-    session_id: Optional[str],
-    question: str,
-    answer: str,
-    matched_nodes: List[Dict[str, Any]],
-):
-    if not session_id or not matched_nodes:
-        return
-
-    manager = _get_expanded_node_manager(session_id)
-    if manager is None:
-        return
-
-    entities = extract_entities_from_text(answer, max_entities=12)
-    usage = manager.record_response_usage(answer=answer, matches=matched_nodes, attached_entities=entities)
-    promoted_names = usage.get("promoted") or []
-    if not promoted_names:
-        return
-
-    try:
-        session_rag = await _get_session_rag_or_raise(session_id)
-        G = session_rag.graphcore.chunk_entity_relation_graph
-        changed = False
-
-        for name in promoted_names:
-            record = manager.get(name)
-            if not record:
-                continue
-            roots = [str(x).strip() for x in (record.get("root_ids") or []) if str(x).strip()]
-
-            await G.upsert_node(
-                name,
-                {
-                    "entity_id": name,
-                    "entity_type": "concept",
-                    "description": record.get("reason") or name,
-                    "source_id": "promoted_expansion",
-                    "is_expanded": "0",
-                },
-            )
-            changed = True
-
-            for ent in entities[:8]:
-                if not ent or ent == name:
-                    continue
-                await G.upsert_node(
-                    ent,
-                    {
-                        "entity_id": ent,
-                        "entity_type": "concept",
-                        "description": f"Extracted from answer for expansion node {name}",
-                        "source_id": "answer_entity",
-                    },
-                )
-                await G.upsert_edge(
-                    name,
-                    ent,
-                    {
-                        "keywords": "co_mentioned",
-                        "description": f"Assistant answer associated {name} with {ent}",
-                        "source_id": "answer_entity",
-                    },
-                )
-                changed = True
-
-            for root in roots[:6]:
-                if not root or root == name:
-                    continue
-                await G.upsert_edge(
-                    name,
-                    root,
-                    {
-                        "keywords": "expanded_from_root",
-                        "description": f"Promoted expansion node linked to root node {root}",
-                        "source_id": "llm_expansion",
-                    },
-                )
-                changed = True
-
-        if changed and hasattr(G, "index_done_callback"):
-            try:
-                await G.index_done_callback(force_save=True)
-            except TypeError:
-                await G.index_done_callback()
-    except Exception:
-        return
+def _get_agent_memory_core() -> AgentMemoryCore:
+    return AgentMemoryCore(
+        get_claw_manager=get_session_claw_manager,
+        get_expanded_node_manager=_get_expanded_node_manager,
+        get_session_rag=_get_session_rag_or_raise,
+        get_memory_engine=get_session_memory_engine,
+        ingest_chat_turn=_ingest_chat_turn,
+        chat_turn_ingest_enabled=_is_chat_turn_ingest_enabled,
+    )
 
 
 # ── Unified background enrichment ──────────────────────────────────
@@ -526,35 +447,18 @@ async def _background_post_query_enrichment(
 ) -> None:
     """All post-query intelligence — runs in background, never blocks the user."""
     _t0 = time.time()
-
-    # 1. Update claw tiered memory (MEMORY.md + semantic archive)
-    claw_mgr = get_session_claw_manager(session_id)
-    if claw_mgr:
-        try:
-            await claw_mgr.post_query_update(question, answer, session_id, time.time())
-        except Exception as exc:
-            _log.warning("[bg_enrich] claw memory update failed: %s", exc)
-
-    # 2. Chat-turn ingest (feed Q&A back into KG)
-    if _is_chat_turn_ingest_enabled():
-        try:
-            await _ingest_chat_turn(question, answer, session_id, time.time())
-        except Exception as exc:
-            _log.warning("[bg_enrich] chat turn ingest failed: %s", exc)
-
-    # 3. Promote expanded nodes that were matched in the *current* query
-    if matched_expanded:
-        try:
-            await _promote_expanded_nodes_in_background(
-                session_id, question, answer, matched_expanded,
-            )
-        except Exception as exc:
-            _log.warning("[bg_enrich] expanded node promotion failed: %s", exc)
-
+    memory_core = _get_agent_memory_core()
+    result = await memory_core.after_response(
+        session_id=session_id,
+        question=question,
+        answer=answer,
+        matched_expanded=matched_expanded,
+    )
     _log.info(
-        "[bg_enrich] session %s done in %.2fs",
+        "[bg_enrich] session %s done in %.2fs: %s",
         session_id,
         time.time() - _t0,
+        result,
     )
 
 
@@ -617,85 +521,42 @@ async def query_stream(request: QueryRequest, background_tasks: BackgroundTasks)
                 yield yield_chunk(ans)
                 return
 
-        expanded_matches = []
-        expanded_instruction = ""
-        merged_instruction = str(request.retrieval_instruction or "").strip()
-        memory_summaries: list = []
         answer_mode = "rag"
-
-        # Phase 1: Build memory context from claw tiered memory
         if request.enable_thinking and not is_identity_query:
             answer_mode = "session_thinking"
-
-            claw_mgr = get_session_claw_manager(request.session_id)
-            if claw_mgr:
-                try:
-                    claw_context = await claw_mgr.build_memory_context(
-                        request.question, enable_archive=True,
-                    )
-                    if claw_context:
-                        merged_instruction = _merge_retrieval_instruction(
-                            merged_instruction, claw_context,
-                        )
-                        memory_summaries = [{"source": "claw", "injected": True}]
-                    _log.info("[T+%ss] claw memory context injected (%d chars)",
-                              _elapsed(), len(claw_context or ""))
-                except Exception as exc:
-                    _log.warning("[T+%ss] claw memory context failed: %s", _elapsed(), exc)
-
         if not is_identity_query:
             yield yield_status("正在检索知识...")
 
-            # Token-based expanded matching is pure CPU (~10ms), always run
-            if request.enable_expanded_matching and not expanded_matches:
-                expanded_manager = _get_expanded_node_manager(request.session_id)
-                if expanded_manager:
-                    expanded_matches = expanded_manager.match_nodes(
-                        query=request.question,
-                        top_k=max(1, request.expanded_top_k),
-                        min_score=max(0.0, request.expanded_min_score),
-                    )
-                    if expanded_matches:
-                        expanded_manager.mark_hits([m.get("entity", "") for m in expanded_matches])
-                        expanded_instruction = expanded_manager.build_forced_instruction(
-                            expanded_matches, limit=min(2, max(1, request.expanded_top_k)),
-                        )
-                        merged_instruction = _merge_retrieval_instruction(merged_instruction, expanded_instruction)
+        recall_bundle = await _get_agent_memory_core().recall(
+            session_id=request.session_id,
+            query=request.question,
+            base_instruction=str(request.retrieval_instruction or ""),
+            mode=request.mode,
+            enable_thinking=request.enable_thinking,
+            enable_expanded_matching=request.enable_expanded_matching,
+            expanded_top_k=request.expanded_top_k,
+            expanded_min_score=request.expanded_min_score,
+            skip_memory=is_identity_query,
+        )
+        expanded_matches = recall_bundle.expanded_matches
+        episodic_matches = recall_bundle.episodic_matches
+        merged_instruction = recall_bundle.retrieval_instruction
+        memory_summaries = recall_bundle.memory_summaries
 
         _log.info("[T+%ss] phase1 done", _elapsed())
-
-        thinking_process = _format_thinking_process(
-            {
-                "memory_hits": len(memory_summaries),
-                "mode": request.mode,
-                "expanded_hits": len(expanded_matches),
-                "memory_context_injected": bool(memory_summaries),
-            },
-            {
-                "memory_mode": effective_memory_mode,
-                "retrieval_instruction": merged_instruction,
-            },
-        )
+        thinking_process = recall_bundle.trace.format_for_response(request.mode)
 
         yield yield_meta({
             "thinking_process": thinking_process,
             "answer_mode": answer_mode,
             "expanded_matches": expanded_matches[:min(2, len(expanded_matches))],
+            "episodic_matches": episodic_matches[:min(3, len(episodic_matches))],
             "memory_summaries": memory_summaries,
             "mode": request.mode,
         })
 
         # Build conversation history for LLM context
-        conversation_history: List[Dict[str, str]] = []
-        try:
-            raw_history = state.session_manager.get_history(request.session_id)
-            for msg in raw_history[-6:]:
-                conversation_history.append({
-                    "role": msg.get("role", "user"),
-                    "content": msg.get("content", ""),
-                })
-        except Exception:
-            pass
+        conversation_history = _get_recent_conversation_history(request.session_id)
 
         # Phase 2: Generation (keyword extraction + retrieval + LLM)
         full_answer = ""
@@ -848,45 +709,25 @@ async def query(request: QueryRequest, background_tasks: BackgroundTasks):
     thinking_process: Optional[str] = None
     answer_mode = "rag"
 
-    expanded_matches: List[Dict[str, Any]] = []
-    expanded_instruction = ""
-    merged_instruction = str(request.retrieval_instruction or "").strip()
-    memory_summaries: list = []
-
-    # Phase 1: Build memory context from claw tiered memory
+    conversation_history = _get_recent_conversation_history(request.session_id)
     if request.enable_thinking and not is_identity_query:
         answer_mode = "session_thinking"
 
-        claw_mgr = get_session_claw_manager(request.session_id)
-        if claw_mgr:
-            try:
-                import asyncio as _aio
-                claw_context = await claw_mgr.build_memory_context(
-                    request.question, enable_archive=True,
-                )
-                if claw_context:
-                    merged_instruction = _merge_retrieval_instruction(
-                        merged_instruction, claw_context,
-                    )
-                    memory_summaries = [{"source": "claw", "injected": True}]
-            except Exception:
-                pass
-
-    if request.enable_expanded_matching and not is_identity_query and not expanded_matches:
-        expanded_manager = _get_expanded_node_manager(request.session_id)
-        if expanded_manager:
-            expanded_matches = expanded_manager.match_nodes(
-                query=request.question,
-                top_k=max(1, request.expanded_top_k),
-                min_score=max(0.0, request.expanded_min_score),
-            )
-            if expanded_matches:
-                expanded_manager.mark_hits([m.get("entity", "") for m in expanded_matches])
-                expanded_instruction = expanded_manager.build_forced_instruction(
-                    expanded_matches,
-                    limit=min(2, max(1, request.expanded_top_k)),
-                )
-                merged_instruction = _merge_retrieval_instruction(merged_instruction, expanded_instruction)
+    recall_bundle = await _get_agent_memory_core().recall(
+        session_id=request.session_id,
+        query=request.question,
+        base_instruction=str(request.retrieval_instruction or ""),
+        mode=request.mode,
+        enable_thinking=request.enable_thinking,
+        enable_expanded_matching=request.enable_expanded_matching,
+        expanded_top_k=request.expanded_top_k,
+        expanded_min_score=request.expanded_min_score,
+        skip_memory=is_identity_query,
+    )
+    expanded_matches = recall_bundle.expanded_matches
+    episodic_matches = recall_bundle.episodic_matches
+    merged_instruction = recall_bundle.retrieval_instruction
+    memory_summaries = recall_bundle.memory_summaries
 
     # Phase 2: Generation
     try:
@@ -935,18 +776,7 @@ async def query(request: QueryRequest, background_tasks: BackgroundTasks):
                 answer = ""
 
             if request.enable_thinking:
-                thinking_process = _format_thinking_process(
-                    {
-                        "memory_hits": len(memory_summaries),
-                        "mode": request.mode,
-                        "expanded_hits": len(expanded_matches),
-                        "memory_context_injected": bool(memory_summaries),
-                    },
-                    {
-                        "memory_mode": effective_memory_mode,
-                        "retrieval_instruction": merged_instruction,
-                    },
-                )
+                thinking_process = recall_bundle.trace.format_for_response(request.mode)
 
             if hasattr(session_rag, "get_last_query_evidence"):
                 sources = _build_sources_from_details({}, session_rag.get_last_query_evidence())
@@ -1008,6 +838,8 @@ async def query(request: QueryRequest, background_tasks: BackgroundTasks):
             "sources": sources,
             "answer_mode": answer_mode,
             "expanded_matches": expanded_matches[:min(2, len(expanded_matches))],
+            "episodic_matches": episodic_matches[:min(3, len(episodic_matches))],
+            "memory_trace": recall_bundle.trace.events,
             "retrieval_instruction_applied": bool(merged_instruction),
             "memory_summaries": memory_summaries,
         }

--- a/tests/test_memory_core_unit.py
+++ b/tests/test_memory_core_unit.py
@@ -1,0 +1,141 @@
+import unittest
+from docthinker.memory_core import AgentMemoryCore
+
+
+class _FakeClawManager:
+    def __init__(self):
+        self.updated = False
+
+    async def build_memory_context(self, query, *, enable_archive=True):
+        return f"memory for {query}"
+
+    async def post_query_update(self, question, answer, session_id=None, timestamp=None):
+        self.updated = True
+
+
+class _FakeExpandedManager:
+    def __init__(self):
+        self.hit_entities = []
+        self.usage_recorded = False
+
+    def match_nodes(self, *, query, top_k=2, min_score=0.2, memory_terms=None):
+        return [
+            {
+                "entity": "Working Memory",
+                "description": "A short-lived agent memory layer",
+                "score": 0.9,
+                "root_ids": ["Agent Memory"],
+            }
+        ][:top_k]
+
+    def mark_hits(self, entities):
+        self.hit_entities.extend(entities)
+
+    def build_forced_instruction(self, matches, *, limit=2):
+        names = ", ".join(m["entity"] for m in matches[:limit])
+        return f"use expanded nodes: {names}"
+
+    def record_response_usage(self, *, answer, matches, attached_entities=None):
+        self.usage_recorded = True
+        return {"used": ["Working Memory"], "promoted": []}
+
+
+class _FakeEpisode:
+    episode_id = "ep-1"
+    summary = "A previous agent solved a planning problem by recalling recent goals."
+    source_type = "chat"
+    concepts = ["planning", "goals"]
+    entity_ids = ["Agent Memory"]
+
+
+class _FakeMemoryEngine:
+    def __init__(self):
+        self.added = False
+
+    async def retrieve_analogies(self, query, *, top_k=10, then_spread=True, spread_top_k=5):
+        return [(_FakeEpisode(), 0.82, "similar goal-driven recall")]
+
+    async def add_observation(self, **kwargs):
+        self.added = True
+        return _FakeEpisode()
+
+
+class AgentMemoryCoreUnitTest(unittest.IsolatedAsyncioTestCase):
+    async def test_recall_merges_claw_context_and_expanded_nodes(self):
+        claw = _FakeClawManager()
+        expanded = _FakeExpandedManager()
+        core = AgentMemoryCore(
+            get_claw_manager=lambda _sid: claw,
+            get_expanded_node_manager=lambda _sid: expanded,
+            get_session_rag=lambda _sid: None,
+        )
+
+        bundle = await core.recall(
+            session_id="#00001",
+            query="what should the agent remember?",
+            base_instruction="base",
+            mode="hybrid",
+            enable_thinking=True,
+            enable_expanded_matching=True,
+        )
+
+        self.assertIn("base", bundle.retrieval_instruction)
+        self.assertIn("memory for what should the agent remember?", bundle.retrieval_instruction)
+        self.assertIn("use expanded nodes: Working Memory", bundle.retrieval_instruction)
+        self.assertEqual(1, len(bundle.memory_summaries))
+        self.assertEqual(1, len(bundle.expanded_matches))
+        self.assertEqual(["Working Memory"], expanded.hit_entities)
+        self.assertTrue(bundle.trace.memory_context_injected)
+        self.assertEqual(1, bundle.trace.expanded_hits)
+
+    async def test_recall_includes_episodic_analogies(self):
+        memory = _FakeMemoryEngine()
+        core = AgentMemoryCore(
+            get_claw_manager=lambda _sid: None,
+            get_expanded_node_manager=lambda _sid: None,
+            get_session_rag=lambda _sid: None,
+            get_memory_engine=lambda _sid: memory,
+        )
+
+        bundle = await core.recall(
+            session_id="#00001",
+            query="how should the agent use memory?",
+            enable_thinking=True,
+            enable_expanded_matching=False,
+        )
+
+        self.assertEqual(1, len(bundle.episodic_matches))
+        self.assertIn("情节记忆与类比参考", bundle.retrieval_instruction)
+        self.assertEqual(1, bundle.trace.episodic_hits)
+        self.assertEqual("episodic_recall", bundle.trace.events[0]["type"])
+
+    async def test_after_response_updates_memory_layers(self):
+        claw = _FakeClawManager()
+        expanded = _FakeExpandedManager()
+        memory = _FakeMemoryEngine()
+        core = AgentMemoryCore(
+            get_claw_manager=lambda _sid: claw,
+            get_expanded_node_manager=lambda _sid: expanded,
+            get_session_rag=lambda _sid: None,
+            get_memory_engine=lambda _sid: memory,
+            ingest_chat_turn=None,
+            chat_turn_ingest_enabled=lambda: False,
+        )
+
+        result = await core.after_response(
+            session_id="#00001",
+            question="q",
+            answer="Working Memory is useful for recent context.",
+            matched_expanded=[{"entity": "Working Memory", "score": 0.9}],
+        )
+
+        self.assertTrue(result["updated"])
+        self.assertTrue(result["claw_updated"])
+        self.assertTrue(claw.updated)
+        self.assertTrue(result["episode_added"])
+        self.assertTrue(memory.added)
+        self.assertTrue(expanded.usage_recorded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added `docthinker.memory_core` as a unified agentic memory facade for recall and post-response consolidation.
- Routed query-time memory assembly through `AgentMemoryCore` for Claw context, Neuro Memory episodic analogies, and expanded KG matches.
- Added lightweight package exports so memory core can be imported without pulling server/runtime dependencies.
- Added focused unit tests and updated architecture docs around the agentic memory framework direction.

## Why

The project is evolving from document RAG toward an agentic memory framework. This separates memory orchestration from API routing and gives future agents a stable recall/consolidation interface.

## Validation

- `python3 -m compileall -q docthinker/memory_core docthinker/__init__.py docthinker/server/routers/query.py tests/test_memory_core_unit.py`
- `python3 -m unittest tests.test_memory_core_unit -v`

Note: full repository test discovery still has pre-existing environment/legacy module failures such as missing `fastapi`, `pydantic`, `dotenv`, and removed `causal/flow/trigraph` modules.